### PR TITLE
Workaround no pn-tok

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Set belle-sip tag to change its version from 4.3.2 to 4.3.3
 ```bash
 cd linphone-sdk/belle-sip/
 git tag -d 4.3.2
-git tag -d 4.3.3
 git tag 4.3.3 -m 4.3.3 5f98e97f98e32baccdf6f033308a0329fdc36e55
 cd -
 ```

--- a/README.md
+++ b/README.md
@@ -180,13 +180,6 @@ git tag 4.3.3 -m 4.3.3 5f98e97f98e32baccdf6f033308a0329fdc36e55
 cd -
 ```
 
-
-Build fails if bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/; let it fail first time, than copy the file where it is expected
-```bash
-rm -fr WORK; ./prepare.py flexisip-rpm -DENABLE_CONFERENCE=ON -DENABLE_JWE_AUTH_PLUGIN=ON -DENABLE_EXTERNAL_AUTH_PLUGIN=ON -DENABLE_PRESENCE=ON -DENABLE_PROTOBUF=ON -DENABLE_SNMP=ON -DENABLE_SOCI=ON -DENABLE_TRANSCODER=ON; make -j1
-cp ./submodules/externals/sofia-sip/bc-sofia-sip-1.13.44bc.tar.gz ./WORK/flexisip-rpm/rpmbuild/SOURCES/
-```
-
 Launch build
 ``bash
 rm -fr WORK; ./prepare.py flexisip-rpm -DENABLE_CONFERENCE=ON -DENABLE_JWE_AUTH_PLUGIN=ON -DENABLE_EXTERNAL_AUTH_PLUGIN=ON -DENABLE_PRESENCE=ON -DENABLE_PROTOBUF=ON -DENABLE_SNMP=ON -DENABLE_SOCI=ON -DENABLE_TRANSCODER=ON; make -j1

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ make -j1 # The build MUST be sequential
 
 Install build dependency
 ```bash
-yum install -y devtoolset-9 devtoolset-9-runtime devtoolset-9-binutils* devtoolset-9-elfutils* devtoolset-9-gcc* devtoolset-9-make devtoolset-9-toolchain pystache libxml2-devel xerces-c-devel xsd soci-sqlite3-devel soci-postgresql-devel soci-odbc-devel soci-mysql-devel speex-devel mbedtls-devel libsrtp15-devel alsa-lib-devel openssl-devel bison nasm intltool doxygen rpm-build cmake3 postgresql-devel python-six python-devel libtool jansson-devel libnghttp2-devel net-snmp-devel protobuf-devel
+yum install -y devtoolset-9 devtoolset-9-runtime devtoolset-9-binutils* devtoolset-9-elfutils* devtoolset-9-gcc* devtoolset-9-make devtoolset-9-toolchain pystache libxml2-devel xerces-c-devel xsd soci-sqlite3-devel soci-postgresql-devel soci-odbc-devel soci-mysql-devel speex-devel mbedtls-devel libsrtp15-devel alsa-lib-devel openssl-devel bison nasm intltool doxygen rpm-build cmake3 postgresql-devel python-six python-devel libtool jansson-devel libnghttp2-devel net-snmp-devel protobuf-devel at
 ln -sf /usr/bin/cmake3 /usr/bin/cmake
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ git checkout pn-tok
 git submodule sync && git submodule update --init --recursive
 ```
 
+Build fails if bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/
+```bash
+cp ./submodules/externals/sofia-sip/bc-sofia-sip-1.13.44bc.tar.gz ./WORK/flexisip-rpm/rpmbuild/SOURCES/
+```
+
 Launch build
 ``bash
 rm -fr WORK; ./prepare.py flexisip-rpm -DENABLE_CONFERENCE=ON -DENABLE_JWE_AUTH_PLUGIN=ON -DENABLE_EXTERNAL_AUTH_PLUGIN=ON -DENABLE_PRESENCE=ON -DENABLE_PROTOBUF=ON -DENABLE_SNMP=ON -DENABLE_SOCI=ON -DENABLE_TRANSCODER=ON; make -j1
-```
-
-Build fails beccause bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/, launch this command from another shell suddenly after build is started
-```bash
-cp ./submodules/externals/sofia-sip/bc-sofia-sip-1.13.44bc.tar.gz ./WORK/flexisip-rpm/rpmbuild/SOURCES/
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -165,8 +165,25 @@ git checkout pn-tok
 git submodule sync && git submodule update --init --recursive
 ```
 
-Build fails if bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/
+Set git tag 2.04 to current branch to set flexisip version
 ```bash
+git tag -d 2.0.4
+git tag 2.0.4
+```
+
+Set belle-sip tag to change its version from 4.3.2 to 4.3.3
+```bash
+cd linphone-sdk/belle-sip/
+git tag -d 4.3.2
+git tag -d 4.3.3
+git tag 4.3.3 -m 4.3.3 5f98e97f98e32baccdf6f033308a0329fdc36e55
+cd -
+```
+
+
+Build fails if bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/; let it fail first time, than copy the file where it is expected
+```bash
+rm -fr WORK; ./prepare.py flexisip-rpm -DENABLE_CONFERENCE=ON -DENABLE_JWE_AUTH_PLUGIN=ON -DENABLE_EXTERNAL_AUTH_PLUGIN=ON -DENABLE_PRESENCE=ON -DENABLE_PROTOBUF=ON -DENABLE_SNMP=ON -DENABLE_SOCI=ON -DENABLE_TRANSCODER=ON; make -j1
 cp ./submodules/externals/sofia-sip/bc-sofia-sip-1.13.44bc.tar.gz ./WORK/flexisip-rpm/rpmbuild/SOURCES/
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,42 @@ make -C ./work -j<njobs>
 make -j1 # The build MUST be sequential
 ```
 
+## Build RPM on NethServer 7
+
+Install build dependency
+```bash
+yum install -y devtoolset-9 devtoolset-9-runtime devtoolset-9-binutils* devtoolset-9-elfutils* devtoolset-9-gcc* devtoolset-9-make devtoolset-9-toolchain pystache libxml2-devel xerces-c-devel xsd soci-sqlite3-devel soci-postgresql-devel soci-odbc-devel soci-mysql-devel speex-devel mbedtls-devel libsrtp15-devel alsa-lib-devel openssl-devel bison nasm intltool doxygen rpm-build cmake3 postgresql-devel python-six python-devel libtool jansson-devel libnghttp2-devel net-snmp-devel protobuf-devel
+ln -sf /usr/bin/cmake3 /usr/bin/cmake
+```
+
+Switch to devtoolset 9
+```bash
+scl enable devtoolset-9 bash
+```
+
+Remove packages if installed on system
+```bash
+rpm -e --nodeps bc-flexisip bc-soci bc-belr bc-liblinphone bc-hiredis bc-ortp bc-mediastreamer bc-sofia-sip bc-bctoolbox bc-belle-sip
+```
+
+clone repo
+```bash
+git clone git@github.com:nethesis/flexisip.git
+cd flexisip
+git checkout pn-tok
+git submodule sync && git submodule update --init --recursive
+```
+
+Launch build
+``bash
+rm -fr WORK; ./prepare.py flexisip-rpm -DENABLE_CONFERENCE=ON -DENABLE_JWE_AUTH_PLUGIN=ON -DENABLE_EXTERNAL_AUTH_PLUGIN=ON -DENABLE_PRESENCE=ON -DENABLE_PROTOBUF=ON -DENABLE_SNMP=ON -DENABLE_SOCI=ON -DENABLE_TRANSCODER=ON; make -j1
+```
+
+Build fails beccause bc-sofia-sip-1.13.44bc.tar.gz is missing from WORK/flexisip-rpm/rpmbuild/SOURCES/, launch this command from another shell suddenly after build is started
+```bash
+cp ./submodules/externals/sofia-sip/bc-sofia-sip-1.13.44bc.tar.gz ./WORK/flexisip-rpm/rpmbuild/SOURCES/
+```
+
 ## Docker
 
 A docker image can be build from sources with command:

--- a/src/module-pushnotification.cc
+++ b/src/module-pushnotification.cc
@@ -484,19 +484,19 @@ void PushNotification::parseLegacyPushParams(const shared_ptr<MsgSip> &ms, const
 	try {
 		pinfo.mDeviceToken = UriUtils::getParamValue(params, "pn-tok");
 	} catch (const out_of_range &) {
-		throw runtime_error("no pn-tok");
+		LOGD("no pn-tok. Continue anyway.");
 	}
 
 	try {
 		pinfo.mAppId = UriUtils::getParamValue(params, "app-id");
 	} catch (const out_of_range &) {
-		throw runtime_error("no app-id");
+		LOGD("no app-id. Continue anyway.");
 	}
 
 	try {
 		pinfo.mType = UriUtils::getParamValue(params, "pn-type");
 	} catch (const out_of_range &) {
-		throw runtime_error("no pn-type");
+		LOGD("no pn-type. Continue anyway.");
 	}
 
 	if (pinfo.mType == "apple") {
@@ -570,9 +570,8 @@ void PushNotification::makePushNotification(const shared_ptr<MsgSip> &ms,
 				SLOGE << "Error while parsing lecacy push notification parameters from request-uri: " << e.what();
 				return;
 			}
-		}else {
-			LOGD("Request has no push notification parameters. Destination client probably didn't submitted them in REGISTER.");
-			return;
+		} else {
+			LOGD("Request has no push notification parameters. Destination client probably didn't submitted them in REGISTER. Continue anyway");
 		}
 
 		// Extract the unique id if possible.


### PR DESCRIPTION
The NethCTI App doesn't always send `pn-tok` parameter to Flexisip upon registration.
If Flexisip doesn't receive such parameter, it doesn't forward the notification to the external helper.
Moreover, pn-tok seems to get lost upon Flexisip restart preventing notification to all clients which registered before the restart.

This patch tries to rebuild Flexisip 2.0.4 by ignoring the `pn-tok` parameter.
This is just a workaround and the real fix should be done inside the mobile application.

https://github.com/nethesis/dev/issues/6021